### PR TITLE
removed setter underscore from helpfile to clear compiler warning

### DIFF
--- a/HelpSource/Classes/ClockFace.schelp
+++ b/HelpSource/Classes/ClockFace.schelp
@@ -34,14 +34,14 @@ Stops the clock
 
 
 
-METHOD:: cursecs_
+METHOD:: cursecs
 sets the time on the clock to curtime. curtime is passed in seconds.
 
 ARGUMENT:: curtime
 new time in seconds
 
 
-METHOD:: tempo_
+METHOD:: tempo
 	sets the current tempo in beats per second. Adjusts the internal TempoClock.
 
 ARGUMENT:: newBPS


### PR DESCRIPTION
Hello,

When adding this quark, I received a compiler warning about `cursecs_` and `tempo_`in the ClockFace.schelp file, prompting me to remove the setter. 

Testing the methods with both setters and setting them equal to a value both seemed to work, so I figure it doesn't hurt the documentation to remove the underscores (and other methods in the same help file do not have underscores).

This is my first pull request, so please let me know if I've done anything wrong, happy to modify!